### PR TITLE
[12.0][FIX] Adaptado para tornar o sale_direct_sale independente

### DIFF
--- a/stock_dropshipping_from_sale_order/__manifest__.py
+++ b/stock_dropshipping_from_sale_order/__manifest__.py
@@ -11,13 +11,15 @@
     'website': 'www.escodoo.com.br',
     'depends': [
         'sale',
+        'sale_direct_sale',
         'stock',
         'stock_picking_sale_order_link',
     ],
     'data': [
         'views/stock_location_route.xml',
+        'views/sale_order.xml',
         'data/stock_data.xml',
-    ],
+    ],''
     'demo': [
     ],
 }

--- a/stock_dropshipping_from_sale_order/models/__init__.py
+++ b/stock_dropshipping_from_sale_order/models/__init__.py
@@ -1,1 +1,2 @@
 from . import stock_location_route
+from . import sale_order_line

--- a/stock_dropshipping_from_sale_order/models/sale_order_line.py
+++ b/stock_dropshipping_from_sale_order/models/sale_order_line.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Marcel Savegnago - Escodoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+
+
+class SaleOrderLine(models.Model):
+
+    _inherit = 'sale.order.line'
+
+    direct_sale = fields.Boolean(
+        related='route_id.direct_sale',
+        store=True,
+        string='Direct Sale',
+    )

--- a/stock_dropshipping_from_sale_order/views/sale_order.xml
+++ b/stock_dropshipping_from_sale_order/views/sale_order.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 Marcel Savegnago - Escodoo
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="sale_order_form_view">
+        <field name="name">sale.order.form (in stock_dropshipping_from_sale_order)</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/form//field[@name='route_id']" position="replace">
+                <field name="route_id" options="{'no_create': True}" required="True"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree/field[@name='route_id']" position="replace">
+                <field name="route_id" options="{'no_create': True}" required="True"/>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/stock_dropshipping_from_sale_order/views/stock_location_route.xml
+++ b/stock_dropshipping_from_sale_order/views/stock_location_route.xml
@@ -5,7 +5,7 @@
 <odoo>
 
     <record model="ir.ui.view" id="stock_location_route_form_view">
-        <field name="name">stock.location.route.form (in sale_direct_sale)</field>
+        <field name="name">stock.location.route.form (in stock_dropshipping_from_sale_order)</field>
         <field name="model">stock.location.route</field>
         <field name="inherit_id" ref="stock.stock_location_route_form_view"/>
         <field name="arch" type="xml">


### PR DESCRIPTION
O módulo sale_direct_sale ficou independente do stock mas se o stock estiver instalado e este módulo não, o sistema vai gerar uma ordem de entrega com origem o estoque da empresa e não do distribuidor. Porém, este módulo depende do módulo sale_direct_sale.